### PR TITLE
Use empty strings for credentials if not defined in env vars

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -34,9 +34,9 @@ export class IAMCredentialsStrategy implements CredentialsStrategy {
     session: string = null,
     region: string = null
   ) {
-    key = key || env.AWS_ACCESS_KEY_ID;
-    accessKey = accessKey || env.AWS_SECRET_ACCESS_KEY;
-    session = session || env.AWS_SESSION_TOKEN;
+    key = key || env.AWS_ACCESS_KEY_ID || '' ;
+    accessKey = accessKey || env.AWS_SECRET_ACCESS_KEY || '';
+    session = session || env.AWS_SESSION_TOKEN || '';
     region = session || env.AWS_REGION || env.REGION;
 
     this.credentials = new AWS.Credentials(


### PR DESCRIPTION
Thanks for making this! I'm using it with Amplify in a Lambda resolver. It works fine in the cloud, but when mocking locally using `amplify mock api` the AWS credentials are not set and so it attempts to create credentials using `undefined` producing:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be of type string or an instance of Buffer, TypedArray, DataView, or KeyObject. Received undefined
```

This change makes it fallback to empty strings instead, and mocking in Amplify now works 🎉 